### PR TITLE
Optimize collection allocation in deserialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+* 0.13.1
+
+- Improve deserialization performance by pre-sizing collections when reading
+  sets, lists and maps to avoid dynamic resizing.
+
 * 0.13.0
 
 - Server overload behavior: you can set the maximum number of queued requests, and server will throw a TApplicationException if the queue length would be exceeded

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/TProtocolReader.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/TProtocolReader.java
@@ -451,7 +451,7 @@ public class TProtocolReader
             throws Exception
     {
         TSet tSet = protocol.readSetBegin();
-        Set<E> set = new HashSet<>();
+        Set<E> set = new HashSet<>(tSet.size);
         for (int i = 0; i < tSet.size; i++) {
             try {
                 E element = elementCodec.read(protocol);
@@ -468,7 +468,7 @@ public class TProtocolReader
             throws Exception
     {
         TList tList = protocol.readListBegin();
-        List<E> list = new ArrayList<>();
+        List<E> list = new ArrayList<>(tList.size);
         for (int i = 0; i < tList.size; i++) {
             try {
                 E element = elementCodec.read(protocol);
@@ -487,7 +487,7 @@ public class TProtocolReader
     {
 
         TMap tMap = protocol.readMapBegin();
-        Map<K, V> map = new HashMap<>();
+        Map<K, V> map = new HashMap<>(tMap.size);
         for (int i = 0; i < tMap.size; i++) {
             try {
                 K key = keyCodec.read(protocol);


### PR DESCRIPTION
## Summary
- avoid dynamic resizing in `TProtocolReader` by pre-sizing `HashSet`, `ArrayList` and `HashMap`
- document the optimization in `CHANGES.md`

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bac626cc8322af4a79bd1be74aa2