### PR TITLE
Fix map unmarshalling with unknown enum keys

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/TProtocolReader.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/TProtocolReader.java
@@ -489,12 +489,24 @@ public class TProtocolReader
         TMap tMap = protocol.readMapBegin();
         Map<K, V> map = new HashMap<>();
         for (int i = 0; i < tMap.size; i++) {
+            K key;
             try {
-                K key = keyCodec.read(protocol);
+                key = keyCodec.read(protocol);
+            } catch (UnknownEnumValueException e) {
+                // key could not be decoded; skip the value to maintain protocol alignment
+                try {
+                    valueCodec.read(protocol);
+                } catch (UnknownEnumValueException ignored) {
+                    // ignore
+                }
+                continue;
+            }
+
+            try {
                 V value = valueCodec.read(protocol);
                 map.put(key, value);
             } catch (UnknownEnumValueException e) {
-              // continue
+                // value could not be decoded; skip this entry
             }
         }
         protocol.readMapEnd();

--- a/swift-codec/src/test/java/com/facebook/swift/codec/TestUnknownEnumKeyMap.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/TestUnknownEnumKeyMap.java
@@ -1,0 +1,65 @@
+package com.facebook.swift.codec;
+
+import com.facebook.swift.codec.internal.EnumThriftCodec;
+import com.facebook.swift.codec.internal.coercion.DefaultJavaCoercions;
+import com.facebook.swift.codec.metadata.ThriftCatalog;
+import com.facebook.swift.codec.metadata.ThriftType;
+import com.google.common.reflect.TypeToken;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TMap;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TType;
+import org.apache.thrift.transport.TMemoryBuffer;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+/**
+ * Tests that maps with unknown enum keys are properly skipped without corrupting
+ * subsequent entries during decoding.
+ */
+public class TestUnknownEnumKeyMap
+{
+    private ThriftCodecManager codecManager;
+
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        codecManager = new ThriftCodecManager();
+        codecManager.getCatalog().addDefaultCoercions(DefaultJavaCoercions.class);
+
+        ThriftCatalog catalog = codecManager.getCatalog();
+        ThriftType fruitType = catalog.getThriftType(Fruit.class);
+        codecManager.addCodec(new EnumThriftCodec<>(fruitType));
+    }
+
+    @Test
+    public void testSkipUnknownEnumKey()
+            throws Exception
+    {
+        TMemoryBuffer transport = new TMemoryBuffer(64);
+        TProtocol protocol = new TBinaryProtocol(transport);
+
+        protocol.writeMapBegin(new TMap(TType.I32, TType.STRING, 2));
+        protocol.writeI32(123); // unknown enum key
+        protocol.writeString("bad");
+        protocol.writeI32(Fruit.BANANA.ordinal());
+        protocol.writeString("banana");
+        protocol.writeMapEnd();
+
+        // reset protocol for reading
+        protocol = new TBinaryProtocol(transport);
+
+        ThriftCodec<Map<Fruit, String>> mapCodec =
+                codecManager.getCodec(new TypeToken<Map<Fruit, String>>() {});
+
+        Map<Fruit, String> result = mapCodec.read(protocol);
+
+        Assert.assertEquals(result.size(), 1);
+        Assert.assertEquals(result.get(Fruit.BANANA), "banana");
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle unknown enum key decoding in `TProtocolReader.readMap`
- add regression test for skipping unknown enum keys

## Testing
- `mvn -q -pl swift-codec -am test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1280848832290591664fce568ec